### PR TITLE
KISS FEND Fix

### DIFF
--- a/src/tncproto/KissProto.scala
+++ b/src/tncproto/KissProto.scala
@@ -82,10 +82,8 @@ class KissProto(service : AprsService, is : InputStream, os : OutputStream) exte
 
 	def writePacket(p : APRSPacket) {
 		Log.d(TAG, "writePacket: " + p)
-		os.write(Kiss.FEND)
-		os.write(Kiss.CMD_DATA)
-		os.write(p.toAX25Frame())
-		os.write(Kiss.FEND)
+		val combinedData = Array[Byte](Kiss.FEND.toByte, Kiss.CMD_DATA.toByte) ++ p.toAX25Frame() ++ Array[Byte](Kiss.FEND.toByte)
+		os.write(combinedData)
 		os.flush()
 	}
 }


### PR DESCRIPTION
This resolves the data from being on 2 lines down to 1.
This was found when it had caused VARA modem to crash.