### PR TITLE
adding a PTT tail param to prevent PTT from cutting off too early

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -602,4 +602,9 @@
 <string name="freq_control_title">Set Frequency</string>
 <string name="freq_control_hint">144.390</string>
 
+<!-- Digirig PTT Tail Setting -->
+<string name="p_ptt_tail">PTT Tail</string>
+<string name="p_ptt_tail_summary">Extends PTT to ensure full packet TX</string>
+<string name="p_ptt_tail_entry">Enter the tail time [ms]</string>
+
 </resources>

--- a/res/xml/backend_digirig.xml
+++ b/res/xml/backend_digirig.xml
@@ -14,5 +14,14 @@
 		android:defaultValue="115200"
 		android:dialogTitle="@string/p_serial_baudrate" />
 
+        <de.duenndns.EditTextPreferenceWithValue
+                android:key="ptt.tail"
+		android:inputType="number"
+		android:defaultValue="100"
+		android:hint="100"
+		android:title="@string/p_ptt_tail"
+		android:summary="@string/p_ptt_tail_summary"
+		android:dialogTitle="@string/p_ptt_tail_entry" />
+
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/backend/DigiRig.scala
+++ b/src/backend/DigiRig.scala
@@ -48,6 +48,7 @@ class DigiRig(service : AprsService, prefs : PrefsWrapper) extends AfskUploader(
 	val USB_PERM_ACTION = "org.aprsdroid.app.DigiRig.PERM"
 	val ACTION_USB_ATTACHED = "android.hardware.usb.action.USB_DEVICE_ATTACHED"
 	val ACTION_USB_DETACHED = "android.hardware.usb.action.USB_DEVICE_DETACHED"
+	val pttTailTimeMS = prefs.getStringInt("ptt.tail", 200);
 
 	val usbManager = service.getSystemService(Context.USB_SERVICE).asInstanceOf[UsbManager];
 	var thread : UsbThread = null
@@ -182,6 +183,7 @@ class DigiRig(service : AprsService, prefs : PrefsWrapper) extends AfskUploader(
 		while (audioPlaying) {
 			Thread.sleep(10)
 		}
+		Thread.sleep(pttTailTimeMS)
 		ser.setRTS(false)
 
 		if (result)


### PR DESCRIPTION

see discussion here for full context: https://forum.digirig.net/t/aprs-packets-not-decodeable-when-sent-from-android/9676

The audio callback is happening before the audio is actually finished sending and so the PTT wait logic finishes "early". This adds a configurable tail time so that the packet finished TXing. Can be set to 0 if you want to test the "bug", 50ms seems to reliably work, 100ms is set as the default. This is different than an AFSK trailer, this is simply holding the PTT open while the audio DAC finishes playing the AFSK that was generated. 