### PR TITLE
Use configured digipeater path for SEND_PACKET

### DIFF
--- a/src/AprsService.scala
+++ b/src/AprsService.scala
@@ -130,9 +130,13 @@ class AprsService extends Service {
 				Log.d(TAG, "SEND_PACKET ignored, data extra is empty.")
 				return
 			}
-			val p = Parser.parseBody(prefs.getCallSsid(), APP_VERSION, null,
-				data_field)
-			sendPacket(p)
+			val digipath = prefs.getString("digi_path", "WIDE1-1")
+                        val p = Parser.parseBody(
+                            prefs.getCallSsid(),
+                            APP_VERSION,
+                            Digipeater.parseList(digipath, true),
+                            data_field)
+                        sendPacket(p)
 			return
 		} else
 		if (i.getAction() == SERVICE_FREQUENCY) {


### PR DESCRIPTION
This PR updates the `SEND_PACKET` API path so packets created from third-party apps use APRSdroid’s configured digipeater path instead of defaulting to `TCPIP*`.

Currently, `SEND_PACKET` handles the `data` extra with:

```scala
val p = Parser.parseBody(prefs.getCallSsid(), APP_VERSION, null, data_field)
sendPacket(p)
```

Because the digipeater argument is `null`, `APRSPacket` falls back to `TCPIP*`. This means packets submitted through the documented `SEND_PACKET` API do not use the user-configured path such as `WIDE1-1,WIDE2-1`, even when APRSdroid’s native message sender does.

This change mirrors APRSdroid’s existing `newPacket()` behavior by reading the configured `digi_path` preference and passing it to `Parser.parseBody()`:

```scala
val digipath = prefs.getString("digi_path", "WIDE1-1")
val p = Parser.parseBody(
    prefs.getCallSsid(),
    APP_VERSION,
    Digipeater.parseList(digipath, true),
    data_field)
sendPacket(p)
```

I tested this with a third-party ATAK plugin using the documented `org.aprsdroid.app.SEND_PACKET` API. Before this change, packets were generated with `TCPIP*`. After this change, the same API call generated packets using the configured path, for example `WIDE1-1,WIDE2-1`.

This should remain backward-compatible because it does not change the public API or intent extras. It only makes `SEND_PACKET` respect the same configured APRS path used elsewhere in APRSdroid.
